### PR TITLE
Block interaction with overlay when it hidden

### DIFF
--- a/lib/widget/gallery_overlay.dart
+++ b/lib/widget/gallery_overlay.dart
@@ -23,19 +23,22 @@ class GalleryOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedOpacity(
-      opacity: showOverlay ? opacity : 0.0,
-      duration: const Duration(milliseconds: 200),
-      child: StreamBuilder(
-        initialData: initialData,
-        stream: overlayController.stream,
-        builder: (context, AsyncSnapshot<Widget?> snapshot) {
-          if (snapshot.hasData && snapshot.data != null) {
-            return snapshot.data!;
-          } else {
-            return Container();
-          }
-        },
+    return IgnorePointer(
+      ignoring: !showOverlay,
+      child: AnimatedOpacity(
+        opacity: showOverlay ? opacity : 0.0,
+        duration: const Duration(milliseconds: 200),
+        child: StreamBuilder<Widget?>(
+          initialData: initialData,
+          stream: overlayController.stream,
+          builder: (context, snapshot) {
+            if (snapshot.hasData && snapshot.data != null) {
+              return snapshot.data!;
+            } else {
+              return Container();
+            }
+          },
+        ),
       ),
     );
   }


### PR DESCRIPTION
I saw that when the overlay is hidden, it remains interactive. I think this is not quite right